### PR TITLE
Solve #4, allow optional passing of task descriptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/README.md
+++ b/README.md
@@ -22,8 +22,10 @@ Returns the Shipit object, regardless of your context (Grunt or Shipit).
 var shipit = utils.getShipit(gruntOrShipit);
 ```
 
-### utils.registerTask(gruntOrShipit, name, task)
+### utils.registerTask(gruntOrShipit, name, [description,] task)
 Register a task, regardless of your context (Grunt or Shipit).
+
+The description arguement is optional, and will only try to pass along a task description if you are using Grunt (it will be ignored if you are using Shipit).
 
 ##### task `Fn`|`Array<String>`
 Task function or array of task names to run in order. *Note: If in a Grunt context and passing an array of task names, task will always be synchronous/blocking.*

--- a/lib/register-task.js
+++ b/lib/register-task.js
@@ -1,27 +1,51 @@
 /**
  * Register a task from Grunt or Shipit instance.
+ * If optional description argument is used, and taskrunner is grunt
+ * pass along the description for the task.
  */
 
-module.exports = function registerTask(gruntOrShipit, name, task) {
+module.exports = function registerTask(gruntOrShipit, name, desc, task) {
   var shipitMethod = 'blTask';
 
   // Grunt
   if (gruntOrShipit.registerTask) {
-    if (Array.isArray(task)) {
-      return gruntOrShipit.registerTask(name, task);
-    }
-
-    return gruntOrShipit.registerTask(name, function() {
-      var done = this.async();
-      var promise = task();
-
-      if (promise && promise.nodeify) {
-        promise.nodeify(done);
-      } else {
-        done();
+    if (typeof desc !== 'string') {
+      if (Array.isArray(desc)) {
+        return gruntOrShipit.registerTask(name, desc);
       }
-    });
+
+      return gruntOrShipit.registerTask(name, function() {
+        var done = this.async();
+        var promise = desc();
+
+        if (promise && promise.nodeify) {
+          promise.nodeify(done);
+        } else {
+          done();
+        }
+      });
+    } else {
+      if (Array.isArray(task)) {
+        return gruntOrShipit.registerTask(name, desc, task);
+      }
+
+      return gruntOrShipit.registerTask(name, desc, function() {
+        var done = this.async();
+        var promise = task();
+
+        if (promise && promise.nodeify) {
+          promise.nodeify(done);
+        } else {
+          done();
+        }
+      });
+    }
   }
 
-  return gruntOrShipit[shipitMethod](name, task);
+  // Manage calls not using description
+  if (typeof desc !== 'string') {
+    return gruntOrShipit[shipitMethod](name, desc);
+  } else {
+    return gruntOrShipit[shipitMethod](name, task);
+  }
 };

--- a/test/unit/index.js
+++ b/test/unit/index.js
@@ -49,6 +49,18 @@ describe('utils', function() {
       expect(shipit.hasTask('test')).to.equal(true);
       done();
     });
+
+    it('should optionally register a Grunt task with desc.', function(done) {
+      utils.registerTask(grunt, 'test', 'something testy!', task);
+      expect(grunt.task.exists('test')).to.equal(true);
+      done();
+    });
+
+    it('should still register a Shipit task if there is a desc.', function(done) {
+      utils.registerTask(shipit, 'test', 'something testy!', task);
+      expect(shipit.hasTask('test')).to.equal(true);
+      done();
+    });
   });
 
   describe('#equalValues', function() {


### PR DESCRIPTION
Adds ability to optionally have a description to pass along to tasks (supported by Grunt alone) otherwise handles/discards optional argument if task runner is Shipit
- Added test entries with optional argument (don't actually need to check for description output, just need to confirm that the task is registered regardless of taskrunner
- Altered registerTask entry in README
#### Changes README entry for registerTask to:

---
### utils.registerTask(gruntOrShipit, name, [description,] task)

Register a task, regardless of your context (Grunt or Shipit).

The description arguement is optional, and will only try to pass along a task description if you are using Grunt (it will be ignored if you are using Shipit).
